### PR TITLE
Infer lint targets only where oxlint configs exist

### DIFF
--- a/nx-oxlint-e2e/src/nx-oxlint.spec.ts
+++ b/nx-oxlint-e2e/src/nx-oxlint.spec.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { readFileSync, rmSync } from 'fs';
+import { readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 describe('nx-oxlint', () => {
@@ -16,6 +16,21 @@ describe('nx-oxlint', () => {
     projectDirectory = createTestWorkspace(workspaceName, testAppName);
     createTestLib(projectDirectory, testReactLibName, 'react');
     createTestLib(projectDirectory, testTsLibName, 'js');
+
+    // Plugin only infers lint where an oxlint config exist
+    const minimalOxlintConfig = '{}\n';
+    writeFileSync(
+      join(projectDirectory, '.oxlintrc.json'),
+      minimalOxlintConfig,
+    );
+    writeFileSync(
+      join(projectDirectory, 'libs', testReactLibName, '.oxlintrc.json'),
+      minimalOxlintConfig,
+    );
+    writeFileSync(
+      join(projectDirectory, 'libs', testTsLibName, '.oxlintrc.json'),
+      minimalOxlintConfig,
+    );
 
     execSync(`npx nx add nx-oxlint@e2e`, {
       cwd: projectDirectory,
@@ -88,7 +103,11 @@ describe('nx-oxlint', () => {
         expect.objectContaining({
           executor: 'nx-oxlint:lint',
           cache: true,
-          inputs: ['{projectRoot}/**/*', { externalDependencies: ['oxlint'] }],
+          inputs: [
+            '{projectRoot}/.oxlintrc.json',
+            '{projectRoot}/**/*',
+            { externalDependencies: ['oxlint'] },
+          ],
           options: {
             cwd: projectType === 'app' ? '.' : `libs/${projectName}`,
             lintTargetName: 'lint',

--- a/nx-oxlint/README.md
+++ b/nx-oxlint/README.md
@@ -2,7 +2,7 @@
 
 # nx-oxlint
 
-An Nx plugin for [oxlint](https://oxc-project.github.io/docs/guide/usage/linter.html) - a fast ESLint alternative written in Rust.
+An Nx plugin for [oxlint](https://oxc.rs/docs/guide/usage/linter/) — a fast ESLint alternative written in Rust.
 
 ## Quick Setup with generator
 
@@ -16,17 +16,32 @@ This command will:
 
 - Add `nx-oxlint` as a devDependency to your workspace
 - Remove existing `@nx/eslint/plugin` configuration in your `nx.json`
-- Add a plugin configuration for `nx-oxlint` with an interferred `lint` target to your `nx.json`
+- Add a plugin entry for `nx-oxlint` in your `nx.json` so inferred `lint` targets can be registered (see [Lint target inference](#lint-target-inference))
 
 This command will **not**:
 
-- Create an `.oxlintrc.json`, so running `lint` will use the default config. Feel free to add a config file and modify the rules as needed
+- Create an oxlint configuration file. Without a config file next to each `package.json` / `project.json`, the plugin will not infer a `lint` target for that directory (see [Lint target inference](#lint-target-inference))
 
-You might need to update the nx deamon and cache using
+You might need to update the nx daemon and cache using
 
 ```bash
 nx reset
 ```
+
+## Lint target inference
+
+The plugin considers each workspace file that matches `**/{package,project}.json` (every `package.json` or `project.json`). The directory containing that file is treated as a **candidate project root**.
+
+Nx merges an inferred **`lint`** target for that root **only if** an oxlint config file exists in the **same** directory. Resolution order (first match wins, and is used for Nx cache `inputs` and for `--config` when the executor runs without `configFile`):
+
+1. `.oxlintrc.json`
+2. `oxlint.config.ts`
+3. `.oxlintrc`
+4. `oxlint.json`
+
+The first two are the [documented default filenames](https://oxc.rs/docs/guide/usage/linter/config); the last two are extra fallbacks supported by this plugin.
+
+If none of these files are present, that directory does not receive an inferred `lint` target. You can still add an `nx-oxlint:lint` target by hand in `project.json` or under `nx` / `targets` in `package.json`.
 
 ## Manual Setup
 
@@ -36,7 +51,7 @@ nx reset
 npm install nx-oxlint
 ```
 
-### Add plugin to your `nx.json` or
+### Add plugin to your `nx.json`
 
 ```json
 {
@@ -87,7 +102,7 @@ All options are optional. The plugin will use `lint` as default target
 All options are optional. The executor will work with minimal configuration.
 
 - `projectRoot` _(optional)_ - Project root directory (defaults to current project root)
-- `configFile` _(optional)_ - Path to oxlint configuration file (auto-detected by oxlint if not specified, if specified other config files are ignored)
+- `configFile` _(optional)_ - Path to the oxlint configuration file, relative to the workspace root. If omitted, the executor uses the same [default filenames](#lint-target-inference) as the plugin. If set and the file exists, it is passed as `--config`. If set but the file is missing, a warning is printed and oxlint runs without `--config` (no fallback to the default filenames)
 - `fix` _(optional)_ - Automatically fix problems (default: `false`)
 - `format` _(optional)_ - Output format (default: `"default"`)
   - Available formats: `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
@@ -97,6 +112,6 @@ All options are optional. The executor will work with minimal configuration.
 
 ## Configuration
 
-If no config file is passed to the plugin/executor, Oxlint will automatically look for configuration files and even consider nested configs with name `.oxlintrc.json`
+When `configFile` is not set on the executor, this package resolves a config in the project root using the [same rule as inference](#lint-target-inference) and passes it to oxlint. Oxlint also supports features such as [nested configs](https://oxc.rs/docs/guide/usage/linter/nested-config) and the options described in the upstream docs.
 
-See [oxlint documentation](https://oxc-project.github.io/docs/guide/usage/linter.html) for configuration options.
+See the [Oxlint configuration guide](https://oxc.rs/docs/guide/usage/linter/config) and [config file reference](https://oxc.rs/docs/guide/usage/linter/config-file-reference).

--- a/nx-oxlint/src/executors/lint/lint.spec.ts
+++ b/nx-oxlint/src/executors/lint/lint.spec.ts
@@ -408,7 +408,24 @@ describe('Lint Executor', () => {
       );
     });
 
-    it('should find and use default .oxlintrc in project root when .oxlintrc.json does not exist', async () => {
+    it('should find and use oxlint.config.ts when .oxlintrc.json does not exist', async () => {
+      const defaultConfigPath = '/workspace/apps/test-project/oxlint.config.ts';
+      mockExistsSync.mockImplementation((path) => path === defaultConfigPath);
+
+      const options: LintExecutorSchema = {};
+
+      await executor(options, mockContext);
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        `${expectedBinaryPath} apps/test-project --config=${defaultConfigPath}`,
+        expect.any(Object),
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        `Using config file: ${defaultConfigPath}`,
+      );
+    });
+
+    it('should find and use default .oxlintrc in project root when higher-priority configs do not exist', async () => {
       const defaultConfigPath = '/workspace/apps/test-project/.oxlintrc';
       mockExistsSync.mockImplementation((path) => path === defaultConfigPath);
 
@@ -460,12 +477,16 @@ describe('Lint Executor', () => {
 
     it('should prioritize .oxlintrc.json over other config files', async () => {
       const oxlintrcJson = '/workspace/apps/test-project/.oxlintrc.json';
+      const oxlintConfigTs = '/workspace/apps/test-project/oxlint.config.ts';
       const oxlintrc = '/workspace/apps/test-project/.oxlintrc';
       const oxlintJson = '/workspace/apps/test-project/oxlint.json';
 
       mockExistsSync.mockImplementation((path) => {
         return (
-          path === oxlintrcJson || path === oxlintrc || path === oxlintJson
+          path === oxlintrcJson ||
+          path === oxlintConfigTs ||
+          path === oxlintrc ||
+          path === oxlintJson
         );
       });
 

--- a/nx-oxlint/src/executors/lint/lint.ts
+++ b/nx-oxlint/src/executors/lint/lint.ts
@@ -2,6 +2,7 @@ import { PromiseExecutor, ExecutorContext } from '@nx/devkit';
 import { execSync } from 'child_process';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { findOxlintConfigFile } from '../../lib/oxlint-config';
 import { LintExecutorSchema } from './schema';
 
 const runExecutor: PromiseExecutor<LintExecutorSchema> = async (
@@ -27,18 +28,9 @@ const runExecutor: PromiseExecutor<LintExecutorSchema> = async (
       configFilePath = undefined;
     }
   } else {
-    const defaultConfigPaths = [
-      join(context.root, projectRoot, '.oxlintrc.json'),
-      join(context.root, projectRoot, '.oxlintrc'),
-      join(context.root, projectRoot, 'oxlint.json'),
-    ];
-
-    for (const configPath of defaultConfigPaths) {
-      if (existsSync(configPath)) {
-        configFilePath = configPath;
-        break;
-      }
-    }
+    configFilePath = findOxlintConfigFile(
+      join(context.root, projectRoot),
+    );
   }
 
   console.log(`Running oxlint for project: ${context.projectName}`);

--- a/nx-oxlint/src/executors/lint/schema.json
+++ b/nx-oxlint/src/executors/lint/schema.json
@@ -41,7 +41,7 @@
     },
     "configFile": {
       "type": "string",
-      "description": "Path to the oxlint configuration file (.oxlintrc.json)"
+      "description": "Path to the oxlint configuration file (e.g. .oxlintrc.json or oxlint.config.ts), relative to the workspace root"
     },
     "additionalArguments": {
       "type": "string",

--- a/nx-oxlint/src/index.ts
+++ b/nx-oxlint/src/index.ts
@@ -5,8 +5,9 @@ import {
   joinPathFragments,
   TargetConfiguration,
 } from '@nx/devkit';
-import { readdirSync } from 'fs';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
+
+import { findOxlintConfigFile } from './lib/oxlint-config';
 
 export type OxlintFormatOption =
   | 'checkstyle'
@@ -38,7 +39,7 @@ export const createNodesV2: CreateNodesV2<OxlintPluginOptions> = [
         createNodesInternal(configFile, options || {}, context),
       configFiles,
       options,
-      context
+      context,
     );
   },
 ];
@@ -48,11 +49,16 @@ const DEFAULT_LINT_TARGET_NAME = 'lint';
 async function createNodesInternal(
   configFilePath: string,
   options: OxlintPluginOptions,
-  context: CreateNodesContextV2
+  context: CreateNodesContextV2,
 ) {
   const projectRoot = dirname(configFilePath);
-  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-  const hasOxlintConfig = siblingFiles.includes('.oxlintrc.json');
+  const oxlintConfigPath = findOxlintConfigFile(
+    join(context.workspaceRoot, projectRoot),
+  );
+
+  if (!oxlintConfigPath) {
+    return { projects: {} };
+  }
 
   const lintTarget: TargetConfiguration = {
     executor: 'nx-oxlint:lint',
@@ -62,7 +68,7 @@ async function createNodesInternal(
     },
     cache: true,
     inputs: [
-      ...(hasOxlintConfig ? ['{projectRoot}/.oxlintrc.json'] : []),
+      joinPathFragments('{projectRoot}', basename(oxlintConfigPath)),
       joinPathFragments('{projectRoot}', '**', '*'),
       {
         externalDependencies: ['oxlint'],

--- a/nx-oxlint/src/lib/oxlint-config.ts
+++ b/nx-oxlint/src/lib/oxlint-config.ts
@@ -1,0 +1,29 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Default oxlint config filenames under a project directory, first match wins.
+ * Documented auto-discovery: `.oxlintrc.json`, `oxlint.config.ts`
+ * @see https://oxc.rs/docs/guide/usage/linter/config
+ * @see https://oxc.rs/docs/guide/usage/linter/config-file-reference
+ */
+export const DEFAULT_OXLINT_CONFIG_FILENAMES = [
+  '.oxlintrc.json',
+  'oxlint.config.ts',
+  '.oxlintrc',
+  'oxlint.json',
+] as const;
+
+/**
+ * Returns the absolute path to the first existing default oxlint config under
+ * `directory`, or undefined if none exist.
+ */
+export function findOxlintConfigFile(directory: string): string | undefined {
+  for (const name of DEFAULT_OXLINT_CONFIG_FILENAMES) {
+    const fullPath = join(directory, name);
+    if (existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Breaking Change: Lint tasks are only inferred where oxlint configs are present